### PR TITLE
Document $500 compute freemium threshold

### DIFF
--- a/docs/costgraph/introduction-to-costgraph.md
+++ b/docs/costgraph/introduction-to-costgraph.md
@@ -22,3 +22,9 @@ Costgraph aims to replace in the future:
 3. Difficulty for teams looking to perform cost and resource rightsizing efforts for their organisations.
 
 To get started, deploy the operator and get started on our cost improvement journey.
+
+## Pricing
+
+Compute monitoring is free while your monthly node spend stays under $500. Once node spend reaches $500, compute is billed at $15 per node or 2% of node spend, whichever is higher.
+
+The AI assistant (GraphAI and the CostGraph MCP server) and the Pricing API are billed per request, independent of the compute freemium threshold.

--- a/docs/costgraph/introduction-to-costgraph.md
+++ b/docs/costgraph/introduction-to-costgraph.md
@@ -21,10 +21,10 @@ Costgraph aims to replace in the future:
 2. Data tooling across various vendors already providing cost information in less useful modes.
 3. Difficulty for teams looking to perform cost and resource rightsizing efforts for their organisations.
 
-To get started, deploy the operator and get started on our cost improvement journey.
+To get started, deploy the operator and begin your cost improvement journey.
 
 ## Pricing
 
-Compute monitoring is free while your monthly node spend stays under $500. Once node spend reaches $500, compute is billed at $15 per node or 2% of node spend, whichever is higher.
+Compute monitoring is free while your monthly node spend stays under $500. Once your monthly node spend is $500 or more, compute is billed at $15 per node or 2% of node spend, whichever is higher.
 
-The AI assistant (GraphAI and the CostGraph MCP server) and the Pricing API are billed per request, independent of the compute freemium threshold.
+The AI assistant (GraphAI and the Costgraph MCP server) and the Pricing API are billed per request, independent of the compute freemium threshold.

--- a/docs/costgraph/introduction-to-costgraph.md
+++ b/docs/costgraph/introduction-to-costgraph.md
@@ -25,6 +25,6 @@ To get started, deploy the operator and begin your cost improvement journey.
 
 ## Pricing
 
-Compute monitoring is free while your monthly node spend stays under $500. Once your monthly node spend is $500 or more, compute is billed at $15 per node or 2% of node spend, whichever is higher.
+Compute monitoring is free while your monthly spend stays under $500. Above $500, compute is billed at $15 per node or 2% of spend, whichever is higher.
 
 The AI assistant (GraphAI and the Costgraph MCP server) and the Pricing API are billed per request, independent of the compute freemium threshold.


### PR DESCRIPTION
Adds a Pricing section to the CostGraph intro: compute is free while monthly node spend stays under $500, then $15/node or 2% of node spend (whichever is higher). AI assistant and Pricing API remain per-request. Pairs with backend BILLING_COMPUTE_FREEMIUM_CENTS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Costgraph introduction to reword the startup guidance.
  * Added a new **Pricing** section, including:
    * Compute monitoring freemium eligibility ($500/month node spend threshold).
    * Post-threshold compute billing rule ($15 per node or 2% of node spend, whichever is higher).
    * Clarified that GraphAI, the Costgraph MCP server, and the Pricing API are billed **per request** regardless of the freemium threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->